### PR TITLE
xacro: os1_64.urdf.xacro is in this package

### DIFF
--- a/urdf/head/head_ouster.urdf.xacro
+++ b/urdf/head/head_ouster.urdf.xacro
@@ -19,7 +19,7 @@
   <xacro:include filename="$(find talos_data)/urdf/head/head.transmission.xacro" />
   <xacro:include filename="$(find talos_data)/urdf/sensors/orbbec_astra_pro.urdf.xacro" />
   <xacro:include filename="$(find talos_description_calibration)/urdf/calibration/calibration_constants.urdf.xacro" />
-  <xacro:include filename="$(find ouster_os1_64)/urdf/os1_64.urdf.xacro" />
+  <xacro:include filename="$(find talos_bauzil)/urdf/os1_64.urdf.xacro" />
 
   <!--Constant parameters-->
   <xacro:property name="head_friction" value="1.0" />


### PR DESCRIPTION
Hi,

Trying to reproduce https://github.com/stack-of-tasks/talos_integration_tests/pull/17, I got this error:
```
No such file or directory: /opt/openrobots/share/ouster_os1_64/urdf/os1_64.urdf.xacro
when processing file: /opt/openrobots/share/talos_bauzil/urdf/head/head_ouster.urdf.xacro
included from: /opt/openrobots/share/talos_bauzil/urdf/talos_full_v2_ouster.urdf.xacro
```